### PR TITLE
refactor: use carousel from `@qwik/headless` in place of SwiperJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,9 +1104,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@qwik-ui/headless": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@qwik-ui/headless/-/headless-0.6.3.tgz",
-      "integrity": "sha512-ms6IVfQdS81gWeBCosav0pF29sFCmai3ih4cKUpOwhrtpu/VcYWnMH1vHzYypTmmKU2pM0pVFqgnCuDS+qY58w==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@qwik-ui/headless/-/headless-0.6.4.tgz",
+      "integrity": "sha512-ZHKB3UpJGTzOEfy1c8VTppndQb6dZfIXael9DaNxpaSUWI/Zd88lV4fEBNZ1x//FezvbRybHLwJtVpQ8xmvz3g==",
       "dev": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "devDependencies": {
         "@builder.io/qwik": "^1.9.0",
         "@builder.io/qwik-city": "^1.9.0",
-        "@qwik-ui/headless": "^0.6.3",
+        "@qwik-ui/headless": "^0.6.4",
         "@types/eslint": "8.56.10",
         "@types/node": "20.14.11",
         "@typescript-eslint/eslint-plugin": "7.16.1",
@@ -17,7 +17,6 @@
         "eslint": "8.57.0",
         "eslint-plugin-qwik": "^1.9.0",
         "prettier": "3.3.3",
-        "swiper": "^11.1.15",
         "typescript": "5.4.5",
         "undici": "*",
         "vite": "^5.4.11",
@@ -5851,26 +5850,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/swiper": {
-      "version": "11.1.15",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.15.tgz",
-      "integrity": "sha512-IzWeU34WwC7gbhjKsjkImTuCRf+lRbO6cnxMGs88iVNKDwV+xQpBCJxZ4bNH6gSrIbbyVJ1kuGzo3JTtz//CBw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
-        },
-        {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.7.0"
       }
     },
     "node_modules/tabbable": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@builder.io/qwik": "^1.9.0",
     "@builder.io/qwik-city": "^1.9.0",
-    "@qwik-ui/headless": "^0.6.3",
+    "@qwik-ui/headless": "^0.6.4",
     "@types/eslint": "8.56.10",
     "@types/node": "20.14.11",
     "@typescript-eslint/eslint-plugin": "7.16.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint": "8.57.0",
     "eslint-plugin-qwik": "^1.9.0",
     "prettier": "3.3.3",
-    "swiper": "^11.1.15",
     "typescript": "5.4.5",
     "undici": "*",
     "vite": "^5.4.11",

--- a/src/components/ui/monitor.tsx
+++ b/src/components/ui/monitor.tsx
@@ -1,10 +1,5 @@
-import { component$, useContext, useStylesScoped$ } from "@builder.io/qwik";
+import { component$, useStylesScoped$ } from "@builder.io/qwik";
 import { css } from "~/utils/css";
-
-import { BooleanButton } from "./button";
-import { SlidesContextId } from "~/contexts/slides-context";
-import { Image } from "@unpic/qwik";
-import { Slides } from "./slides";
 
 export const Monitor = component$(() => {
   useStylesScoped$(css`
@@ -17,16 +12,17 @@ export const Monitor = component$(() => {
       position: relative;
 
       & iframe {
+        width: 100%;
+        height: 100%;
+
         /* TODO: should be according monitor screen size, and not fixed like this */
         aspect-ratio: 16 / 10;
       }
 
-      & iframe,
-      label {
-        width: 100%;
-        height: 100%;
-      }
-
+      /* TODO: unused until bind:selectedIndex is fixed. 
+               should be used to allow the user to slide
+               the iframe and change the active slide
+      */
       & swiper-container {
         width: 100%;
         height: 100%;
@@ -54,24 +50,9 @@ export const Monitor = component$(() => {
     }
   `);
 
-  const slides = useContext(SlidesContextId);
-
   return (
     <div>
       <iframe src="/present" loading="lazy"></iframe>
-      <Slides.Carousel
-        grab-cursor="true"
-        touch-release-on-edges="true"
-        onMovementToggleClass="moving"
-      >
-        {slides.array.map((s) => (
-          <swiper-slide key={s.id}>
-            <BooleanButton class="wrapper">
-              <Image src={s.preview} />
-            </BooleanButton>
-          </swiper-slide>
-        ))}
-      </Slides.Carousel>
     </div>
   );
 });

--- a/src/components/ui/slides/index.tsx
+++ b/src/components/ui/slides/index.tsx
@@ -83,7 +83,7 @@ export const Carousel = component$<Carousel>((props) => {
 });
 
 export const Item = component$<{ slide: Slide }>((props) => {
-  useStylesScoped$(transitions);
+  useStyles$(transitions);
   useStyles$(css`
     .slide-content {
       max-width: 100%;
@@ -133,7 +133,7 @@ export const Item = component$<{ slide: Slide }>((props) => {
   return (
     <Car.Root>
       <Car.Scroller class="scroller">
-        <Car.Slide class="slide-content">
+        <Car.Slide class={`slide-content ${slides.active == props.slide && 'active'}`}>
           <span>{props.slide.file_name}</span>
           <Image layout="fixed" src={props.slide.preview} />
         </Car.Slide>

--- a/src/components/ui/slides/index.tsx
+++ b/src/components/ui/slides/index.tsx
@@ -1,86 +1,15 @@
-import type { Swiper, SwiperOptions } from "swiper/types";
-import type { PropsOf } from "@builder.io/qwik";
 import {
-  $,
   component$,
-  Slot,
   useContext,
-  useId,
-  useOnDocument,
-  useSignal,
   useStyles$,
-  useStylesScoped$,
-  useTask$,
 } from "@builder.io/qwik";
 import { type Slide, SlidesContextId } from "~/contexts/slides-context";
 import { Image } from "@unpic/qwik";
 import { css } from "~/utils/css";
-import { lettersAndNumbers } from "~/utils/letters-and-numbers-substring";
 import { Button } from "../button";
-import { isBrowser } from "@builder.io/qwik/build";
-import { Carousel as Car } from "@qwik-ui/headless";
+import { Carousel } from "@qwik-ui/headless";
 import transitions from "./slides-transitions.css?inline";
 
-type Carousel = PropsOf<"div"> &
-  SwiperOptions & {
-    onMovementToggleClass?: string;
-  };
-type SwiperElement = HTMLElement & { swiper: Swiper };
-
-export const Carousel = component$<Carousel>((props) => {
-  useStylesScoped$(css`
-    swiper-container {
-      height: 50%;
-    }
-  `);
-
-  const swiper = useSignal<SwiperElement>();
-
-  const slides = useContext(SlidesContextId);
-
-  const id = lettersAndNumbers(useId());
-
-  useOnDocument(
-    `${id}slidechange`,
-    $((e) => {
-      const { swiper } = e.target as SwiperElement;
-      const index = swiper.activeIndex;
-      slides.active = slides.array[index];
-    })
-  );
-
-  useOnDocument(
-    `DOMContentLoaded`,
-    $(() => {
-      if (props.onMovementToggleClass) {
-        document.addEventListener(`${id}sliderfirstmove`, (e) => {
-          const s = e.target as SwiperElement;
-          s.classList.add(props.onMovementToggleClass!);
-        });
-
-        document.addEventListener(`${id}transitionend`, (e) => {
-          const s = e.target as SwiperElement;
-          s.classList.remove(props.onMovementToggleClass!);
-        });
-      }
-    })
-  );
-
-  useTask$(({ track }) => {
-    const active = track(() => slides.active);
-    if (isBrowser && active) {
-      const s = swiper.value!;
-      const index = slides.array.findIndex((s) => s.id == active.id);
-      s.swiper.slideTo(index);
-    }
-  });
-
-  return (
-    <swiper-container ref={swiper} events-prefix={id} {...props}>
-      <Slot />
-    </swiper-container>
-  );
-});
 
 export const Item = component$<{ slide: Slide }>((props) => {
   useStyles$(transitions);
@@ -131,13 +60,13 @@ export const Item = component$<{ slide: Slide }>((props) => {
   const slides = useContext(SlidesContextId);
 
   return (
-    <Car.Root>
-      <Car.Scroller class="scroller">
-        <Car.Slide class={`slide-content ${slides.active == props.slide && 'active'}`}>
+    <Carousel.Root>
+      <Carousel.Scroller class="scroller">
+        <Carousel.Slide class={`slide-content ${slides.active == props.slide && 'active'}`}>
           <span>{props.slide.file_name}</span>
           <Image layout="fixed" src={props.slide.preview} />
-        </Car.Slide>
-        <Car.Slide class="slide-controls">
+        </Carousel.Slide>
+        <Carousel.Slide class="slide-controls">
         <aside role="toolbar" aria-label="Slide controls">
           <Button
             onClick$={() =>
@@ -151,10 +80,10 @@ export const Item = component$<{ slide: Slide }>((props) => {
             aria-label="Delete slide"
           />
         </aside>
-      </Car.Slide>
-      </Car.Scroller>
-    </Car.Root>
+      </Carousel.Slide>
+      </Carousel.Scroller>
+    </Carousel.Root>
   );
 });
 
-export const Slides = { Carousel, Item };
+export const Slides = { Item };

--- a/src/components/ui/slides/index.tsx
+++ b/src/components/ui/slides/index.tsx
@@ -8,6 +8,7 @@ import {
   useId,
   useOnDocument,
   useSignal,
+  useStyles$,
   useStylesScoped$,
   useTask$,
 } from "@builder.io/qwik";
@@ -17,6 +18,7 @@ import { css } from "~/utils/css";
 import { lettersAndNumbers } from "~/utils/letters-and-numbers-substring";
 import { Button } from "../button";
 import { isBrowser } from "@builder.io/qwik/build";
+import { Carousel as Car } from "@qwik-ui/headless";
 import transitions from "./slides-transitions.css?inline";
 
 type Carousel = PropsOf<"div"> &
@@ -82,22 +84,10 @@ export const Carousel = component$<Carousel>((props) => {
 
 export const Item = component$<{ slide: Slide }>((props) => {
   useStylesScoped$(transitions);
-  useStylesScoped$(css`
-    .slide-root {
-      width: 100%;
-      height: 5rem;
-
-      > swiper-container {
-        height: 100%;
-
-        & swiper-slide {
-          width: auto;
-        }
-      }
-    }
-
+  useStyles$(css`
     .slide-content {
       max-width: 100%;
+      flex-grow: 1;
       display: flex;
       justify-content: space-between;
       align-items: center;
@@ -121,11 +111,9 @@ export const Item = component$<{ slide: Slide }>((props) => {
 
       & img {
         width: 25%;
-        height: 100%;
+        aspect-ratio: 1;
+        object-position: center;
         object-fit: contain !important;
-
-        display: grid;
-        place-content: center;
         flex-shrink: 0;
         overflow: hidden;
       }
@@ -135,6 +123,7 @@ export const Item = component$<{ slide: Slide }>((props) => {
       display: flex;
       width: fit-content;
       padding: 1rem;
+      flex-basis: content;
       /* background-color: var(--primary-color); */
     }
   `);
@@ -142,16 +131,13 @@ export const Item = component$<{ slide: Slide }>((props) => {
   const slides = useContext(SlidesContextId);
 
   return (
-    <swiper-container
-      class="slide-root"
-      slides-per-view="auto"
-      touch-release-on-edges="true"
-    >
-      <swiper-slide class="slide-content">
-        <span>{props.slide.file_name}</span>
-        <Image layout="fixed" src={props.slide.preview} />
-      </swiper-slide>
-      <swiper-slide class="slide-controls">
+    <Car.Root>
+      <Car.Scroller class="scroller">
+        <Car.Slide class="slide-content">
+          <span>{props.slide.file_name}</span>
+          <Image layout="fixed" src={props.slide.preview} />
+        </Car.Slide>
+        <Car.Slide class="slide-controls">
         <aside role="toolbar" aria-label="Slide controls">
           <Button
             onClick$={() =>
@@ -165,8 +151,9 @@ export const Item = component$<{ slide: Slide }>((props) => {
             aria-label="Delete slide"
           />
         </aside>
-      </swiper-slide>
-    </swiper-container>
+      </Car.Slide>
+      </Car.Scroller>
+    </Car.Root>
   );
 });
 

--- a/src/components/ui/slides/slides-transitions.css
+++ b/src/components/ui/slides/slides-transitions.css
@@ -1,4 +1,4 @@
-.slide-root {
+.slide-content {
   transition-property: background-color, color;
   transition-duration: 150ms;
   transition-timing-function: ease-in-out;
@@ -23,11 +23,7 @@
     --hover-color: rgb(255, 255, 255, 0.1);
   }
 
-  &:nth-child(even) {
-    --shade-color: rgb(0, 0, 0, 0.1);
-  }
-
-  &.swiper-slide-active {
+  &.active {
     --selected-percentage: 100%;
     color: color-mix(in srgb, var(--bkg-color) 100%, rgb(0, 0, 0) 50%);
   }

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -44,15 +44,6 @@ export default component$(() => {
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
         />
-        {/*------- Libraries -------*/}
-        {/* 
-            TODO: Should be changed to Swiper's NPM module to reduce bundle size
-            @see https://swiperjs.com/element#core-version--modules 
-        */}
-        <script
-          async
-          src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-element-bundle.min.js"
-        ></script>
       </head>
       <body lang="pt-br">
         <SlidesContextProvider>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -24,6 +24,10 @@ export default component$(() => {
         border-radius: 2rem;
         background-color: var(--bkg-color);
         overflow: scroll;
+
+        > :nth-child(even) .slide-content {
+          --shade-color: rgb(0, 0, 0, 0.1);
+        }
       }
     }
   `);
@@ -36,8 +40,7 @@ export default component$(() => {
 
       <ul>
         {slides.array.map((s) => (
-          <Slides.Item key={s.id} slide={s}>
-          </Slides.Item>
+          <Slides.Item key={s.id} slide={s} />
         ))}
       </ul>
     </main>


### PR DESCRIPTION
it has better qwik support and reduces bundle size, being more performant